### PR TITLE
Revert "Bump dawidd6/action-download-artifact from 2 to 6 in /.github/workflows in the github_actions group across 1 directory"

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -17,7 +17,7 @@ jobs:
         ref: ${{ github.event.inputs.commit_hash }}
     - name: Download artifact
       id: download-artifact
-      uses: dawidd6/action-download-artifact@v6
+      uses: dawidd6/action-download-artifact@v2
       with:
         workflow: rust.yml
         workflow_conclusion: ""


### PR DESCRIPTION
Reverts Dargon789/fnm#2

## Summary by Sourcery

CI:
- Downgrade dawidd6/action-download-artifact from version 6 to version 2.