### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - main
-      - dev
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -28,7 +27,7 @@ jobs:
       # pnpm
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x,20.x,22.x
+          node-version: 22
           cache: "pnpm"
 
       - name: Get pnpm store directory


### PR DESCRIPTION
## Summary by Sourcery

Streamline the release workflow by restricting triggers to master and main branches and pin Node.js to version 22.

CI:
- Remove the 'dev' branch from the release workflow triggers
- Pin Node.js version to 22 in the release job