### PR TITLE
Create ci.yml

### DIFF
--- a/.circleci/ci.yml
+++ b/.circleci/ci.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+jobs:
+  build-and-test:
+    docker:
+      - image: cimg/rust:1.89.0
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-cargo-{{ checksum "Cargo.lock" }}
+            - v1-cargo-
+      - run:
+          name: "Check formatting"
+          command: cargo fmt -- --check
+      - run:
+          name: "Run tests"
+          command: cargo test
+      - save_cache:
+          key: v1-cargo-{{ checksum "Cargo.lock" }}
+          paths:
+            - "~/.cargo/bin"
+            - "~/.cargo/registry/index"
+            - "~/.cargo/registry/cache"
+            - "~/.cargo/git/db"
+            - "target"
+      - run:
+          name: "Check formatting"
+          command: cargo fmt -- --check
+      - run:
+          name: "Run tests"
+          command: cargo test


### PR DESCRIPTION
## Summary by Sourcery

Add CircleCI pipeline to build, test, and format-check the Rust project with caching for dependencies

CI:
- Introduce a CircleCI config (.circleci/ci.yml) using cimg/rust:1.89.0
- Run cargo fmt -- --check and cargo test in a single build-and-test job
- Cache Cargo dependencies and build artifacts between builds