### PR TITLE
Update ci.yml

### DIFF
--- a/.circleci/ci.yml
+++ b/.circleci/ci.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build-and-test:
     docker:
-      - image: cimg/rust:1.89.0
+      - image: cimg/rust:1.88.0
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use cimg/rust:1.88.0 instead of cimg/rust:1.89.0 in the CI configuration