### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # set up
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: hecrj/setup-rust-action@v1
         with:


### PR DESCRIPTION
## Summary by Sourcery

Update release workflow to use compatible action versions and Node.js version

CI:
- Downgrade actions/checkout and actions/cache from v4 to v3
- Set Node.js version to 20 in release workflow