### PR TITLE
Update rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - main
+
 concurrency:
   group: ci-${{ github.head_ref }}
   cancel-in-progress: true
@@ -84,9 +84,7 @@ jobs:
           strip target/x86_64-apple-darwin/release/fnm
           cargo build --release --target aarch64-apple-darwin
           strip target/aarch64-apple-darwin/release/fnm
-
           mkdir -p target/release
-
           # create a universal binary
           lipo -create \
             target/x86_64-apple-darwin/release/fnm \
@@ -122,7 +120,7 @@ jobs:
           run_install: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x ,20.x ,22.x
+          node-version: 18.x
           cache: "pnpm"
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -157,7 +155,7 @@ jobs:
           run_install: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x ,20.x ,22.x
+          node-version: 18.x
           cache: "pnpm"
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -193,7 +191,7 @@ jobs:
   #       run_install: false
   #   - uses: actions/setup-node@v3
   #     with:
-  #       node-version: 18.x ,20.x ,22.x
+  #       node-version: 18.x
   #       cache: 'pnpm'
   #   - name: Get pnpm store directory
   #     id: pnpm-cache
@@ -229,7 +227,7 @@ jobs:
           run_install: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x ,20.x ,22.x
+          node-version: 18.x
           cache: "pnpm"
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -316,10 +314,8 @@ jobs:
 
           env: |
             RUST_LOG: fnm=debug
-
           dockerRunArgs: |
             --volume "${PWD}/target/${{matrix.rust_target}}/release:/artifacts"
-
           # Set an output parameter `uname` for use in subsequent steps
           run: |
             echo "Hello from $(uname -a)"
@@ -328,7 +324,6 @@ jobs:
             /artifacts/fnm install 12.0.0
             echo "fnm exec --using=12 -- node --version"
             /artifacts/fnm exec --using=12 -- node --version
-
       - uses: actions/upload-artifact@v4
         with:
           name: fnm-${{ matrix.arch }}
@@ -357,7 +352,7 @@ jobs:
           run_install: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x ,20.x ,22.x
+          node-version: 18.x
           cache: "pnpm"
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -374,7 +369,6 @@ jobs:
       - name: Generate command markdown
         run: |
           pnpm run generate-command-docs --check --binary-path=$(which fnm)
-
       # TODO: use bnz
       # run_e2e_benchmarks:
       #   runs-on: ubuntu-latest
@@ -402,7 +396,7 @@ jobs:
       #         run_install: false
       #     - uses: actions/setup-node@v3
       #       with:
-      #         node-version: 18.x ,20.x ,22.x
+      #         node-version: 18.x
       #         cache: "pnpm"
       #     - name: Get pnpm store directory
       #       id: pnpm-cache


### PR DESCRIPTION
## Summary by Sourcery

Refine the GitHub Actions rust.yml workflow by restricting triggers to the master branch, pinning Node.js to version 18.x across all setup-node steps, and cleaning up formatting and commented version entries.

CI:
- Limit workflow triggers to the master branch only
- Pin Node.js setup in all jobs to version 18.x, removing 20.x and 22.x entries
- Remove redundant commented Node.js version lines and extra blank lines