### PR TITLE
Delete .kodiak.toml

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,1 +1,0 @@
-version = 1


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Delete the deprecated .kodiak.toml configuration file.