### PR TITLE
Add changeset for updating indoc crate to v2.0.7

### DIFF
--- a/.changeset/perfect-beds-notice.md
+++ b/.changeset/perfect-beds-notice.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+chore(deps): update rust crate indoc to v2.0.7


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Record a changeset for bumping the indoc Rust crate dependency to v2.0.7.