### PR TITLE
Update Rust toolchain version to 1.89

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,19 @@
 [toolchain]
-channel = "1.88"
+channel = "1.89"
+chisel-serial = { max-threads = 1 }
 components = ["rustfmt", "clippy"]
+
+[test-groups]
+chisel-serial = { max-threads = 1 }
+
+[profile.default]
+retries = { backoff = "exponential", count = 2, delay = "5s", jitter = true }
+slow-timeout = { period = "1m", terminate-after = 3 }
+
+[[profile.default.overrides]]
+filter = "test(/ext_integration|can_test_forge_std/)"
+slow-timeout = { period = "5m", terminate-after = 4 }
+
+[[profile.default.overrides]]
+filter = "package(foundry-cheatcodes-spec)"
+retries = 0


### PR DESCRIPTION
https://github.com/Dargon789/foundry/commit/c0d08b1943203e4b3bc3fe31805f49ddca6173f0

*Adjust test runner configuration for nextest to better handle long-running and specific tests.

Enhancements:

Introduce a dedicated test group that limits chisel-serial tests to a single thread. Increase the default slow-test timeout period to reduce premature terminations for longer-running tests. Expand the slow-timeout override filter to include both ext_integration and can_test_forge_std tests.

## Summary by Sourcery

Update the Rust toolchain version and tune the test runner configuration to improve handling of long-running and flaky tests.

Build:
- Bump the Rust toolchain channel from 1.88 to 1.89 in rust-toolchain.toml.

Tests:
- Configure a dedicated chisel-serial test group restricted to a single thread in nextest.
- Adjust default and override slow-test timeouts and retry settings, including special handling for ext_integration, can_test_forge_std, and foundry-cheatcodes-spec test packages.