### PR TITLE
Downgrade pnpm/action-setup version to v4.0.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,4 @@
+
 name: Rust
 
 on:
@@ -115,7 +116,7 @@ jobs:
           path: target/release
       - name: mark binary as executable
         run: chmod +x target/release/fnm
-      - uses: pnpm/action-setup@v4.2.0
+      - uses: pnpm/action-setup@v4.0.0
         with:
           run_install: false
       - uses: actions/setup-node@v4
@@ -150,7 +151,7 @@ jobs:
           name: fnm-windows
           path: target/release
       - uses: MinoruSekine/setup-scoop@v4
-      - uses: pnpm/action-setup@v4.2.0
+      - uses: pnpm/action-setup@v4.0.0
         with:
           run_install: false
       - uses: actions/setup-node@v4
@@ -222,7 +223,7 @@ jobs:
           path: target/release
       - name: mark binary as executable
         run: chmod +x target/release/fnm
-      - uses: pnpm/action-setup@v4.2.0
+      - uses: pnpm/action-setup@v4.0.0
         with:
           run_install: false
       - uses: actions/setup-node@v4
@@ -347,7 +348,7 @@ jobs:
         run: |
           sudo install target/release/fnm /bin
           fnm --version
-      - uses: pnpm/action-setup@v4.2.0
+      - uses: pnpm/action-setup@v4.0.0
         with:
           run_install: false
       - uses: actions/setup-node@v4


### PR DESCRIPTION
chore(deps): update rust crate chrono to v0.4.43 #3244  https://github.com/Schniz/fnm/commit/00a76adef9d88188b6c05b0bf7780d6537b6f0d9 [![Rust](https://github.com/Schniz/fnm/actions/workflows/rust.yml/badge.svg)](https://github.com/Schniz/fnm/actions/workflows/rust.yml)

## Summary by Sourcery

CI:
- Align the pnpm/action-setup version to v4.0.0 in all steps of the Rust GitHub Actions workflow.