### PR TITLE
Revert "Downgrade pnpm/action-setup version to v4.0.0"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,3 @@
-
 name: Rust
 
 on:
@@ -116,7 +115,7 @@ jobs:
           path: target/release
       - name: mark binary as executable
         run: chmod +x target/release/fnm
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           run_install: false
       - uses: actions/setup-node@v4
@@ -151,7 +150,7 @@ jobs:
           name: fnm-windows
           path: target/release
       - uses: MinoruSekine/setup-scoop@v4
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           run_install: false
       - uses: actions/setup-node@v4
@@ -223,7 +222,7 @@ jobs:
           path: target/release
       - name: mark binary as executable
         run: chmod +x target/release/fnm
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           run_install: false
       - uses: actions/setup-node@v4
@@ -348,7 +347,7 @@ jobs:
         run: |
           sudo install target/release/fnm /bin
           fnm --version
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           run_install: false
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Reverts Dargon789/fnm#111

## Summary by Sourcery

CI:
- Update GitHub Actions Rust workflow to use pnpm/action-setup v4.2.0 instead of v4.0.0 across all build and release jobs.