### PR TITLE
Remove 'main' branch from release workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove the main branch from the release workflow push branch filters so releases are triggered solely from master.