### PR TITLE
Revert "Remove 'main' branch from release workflow triggers"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Reverts Dargon789/fnm#115

## Summary by Sourcery

Build:
- Re-enable the release GitHub Actions workflow for the main branch alongside master.