### PR TITLE
Create moody-fans-shake.md

### DIFF
--- a/.changeset/moody-fans-shake.md
+++ b/.changeset/moody-fans-shake.md
@@ -2,4 +2,4 @@
 "fnm": patch
 ---
 
-chore(deps): update rust crate indoc to v2.0.7
+chore(deps): update non-major Rust dependencies


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Document a dependency bump of the Rust `indoc` crate to version 2.0.7 via a changeset entry.