### PR TITLE
Revert "Revert "Remove 'main' branch from release workflow triggers""

### DIFF
--- a/.changeset/honest-suns-fetch.md
+++ b/.changeset/honest-suns-fetch.md
@@ -1,0 +1,5 @@
+---
+"fnm": minor
+---
+
+feat: support to install the latest version

--- a/.changeset/itchy-rice-beg.md
+++ b/.changeset/itchy-rice-beg.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Renovate/dawidd6 action download artifact 3.x

--- a/.changeset/smart-ladybugs-punch.md
+++ b/.changeset/smart-ladybugs-punch.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Upgrade dawidd6/action-download-artifact to v3.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       # pnpm
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18.x,20.x,22.x,24.x 
           cache: "pnpm"
 
       - name: Get pnpm store directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
   "name": "fnm",
-  "version": "1.37.0",
+  "version": "1.39.0",
   "private": true,
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/Schniz/fnm.git"
-  },
-  "author": "Gal Schlezinger <gal@spitfire.co.il>",
+  "repository": "github:Dargon789/fnm",
+  "author": "Dargon789 <dargon789.uni.eth>",
   "type": "module",
-  "packageManager": "pnpm@8.15.9+sha256.daa27a0b541bc635323ff96c2ded995467ff9fe6d69ff67021558aa9ad9dcc36",
+  "packageManager": "pnpm@9.15.9",
   "license": "GPLv3",
   "scripts": {
     "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' jest",
@@ -16,7 +13,7 @@
     "generate-command-docs": "./.ci/print-command-docs.js"
   },
   "changelog": {
-    "repo": "Schniz/fnm",
+    "repo": "Dargon789/fnm",
     "labels": {
       "PR: New Feature": "New Feature 🎉",
       "PR: Bugfix": "Bugfix 🐛",
@@ -26,40 +23,30 @@
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.5.1",
-    "@changesets/cli": "2.28.1",
-    "@types/jest": "^29.5.14",
-    "@types/node": "^22.14.0",
-    "@types/shell-escape": "^0.2.3",
-    "chalk": "^5.4.1",
-    "cmd-ts": "0.13.0",
-    "cross-env": "^7.0.3",
-    "execa": "9.5.2",
-    "jest": "^29.7.0",
+    "@changesets/cli": "^2.29.7",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^24.1.0",
+    "@types/shell-escape": "^0.2.1",
+    "chalk": "^5.1.2",
+    "cmd-ts": "0.14.1",
+    "cross-env": "^10.0.0",
+    "execa": "7.2.0",
+    "jest": "^30.0.0",
     "lerna-changelog": "2.2.0",
-    "node-fetch": "^3.3.2",
-    "prettier": "3.5.3",
+    "node-fetch": "^3.3.0",
+    "p-retry": "^7.0.0",
+    "prettier": "3.6.2",
     "pv": "1.0.1",
     "shell-escape": "^0.2.0",
     "svg-term-cli": "2.1.1",
     "toml": "3.0.0",
     "ts-dedent": "^2.2.0",
-    "ts-jest": "^29.2.6",
-    "typescript": "^5.8.2",
-    "which": "^5.0.0",
-    "zod": "^3.24.2"
+    "ts-jest": "^29.0.3",
+    "typescript": "^5.0.0",
+    "which": "^3.0.1",
+    "zod": "^4.0.0"
   },
   "prettier": {
     "semi": false
-  },
-  "description": "<h1 align=\"center\">   Fast Node Manager (<code>fnm</code>)   <img alt=\"Amount of downloads\" src=\"https://img.shields.io/github/downloads/Schniz/fnm/total.svg?style=flat\" />   <a href=\"https://github.com/Schniz/fnm/actions\"><img src=\"https://img.shields.io/github/actions/workflow/status/Schniz/fnm/rust.yml?branch=master&label=workflow\" alt=\"GitHub Actions workflow status\" /></a> </h1>",
-  "bugs": {
-    "url": "https://github.com/Schniz/fnm/issues"
-  },
-  "homepage": "https://github.com/Schniz/fnm#readme",
-  "main": "jest.global-setup.js",
-  "directories": {
-    "doc": "docs",
-    "test": "tests"
-  },
-  "keywords": []
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "fnm",
-  "version": "1.38.1",
+  "version": "1.37.0",
   "private": true,
-  "repository": "git@github.com:Schniz/fnm.git",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/Schniz/fnm.git"
+  },
   "author": "Gal Schlezinger <gal@spitfire.co.il>",
   "type": "module",
-  "packageManager": "pnpm@9.1.4",
+  "packageManager": "pnpm@8.15.9+sha256.daa27a0b541bc635323ff96c2ded995467ff9fe6d69ff67021558aa9ad9dcc36",
   "license": "GPLv3",
   "scripts": {
     "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' jest",
@@ -23,30 +26,40 @@
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.5.1",
-    "@changesets/cli": "2.28.0",
-    "@types/jest": "^30.0.0",
-    "@types/node": "^24.0.0",
-    "@types/shell-escape": "^0.2.1",
-    "chalk": "^5.1.2",
+    "@changesets/cli": "2.28.1",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.14.0",
+    "@types/shell-escape": "^0.2.3",
+    "chalk": "^5.4.1",
     "cmd-ts": "0.13.0",
-    "cross-env": "^10.0.0",
-    "execa": "9.6.1",
-    "jest": "^30.0.0",
+    "cross-env": "^7.0.3",
+    "execa": "9.5.2",
+    "jest": "^29.7.0",
     "lerna-changelog": "2.2.0",
-    "node-fetch": "^3.3.0",
-    "p-retry": "^7.0.0",
-    "prettier": "3.5.1",
+    "node-fetch": "^3.3.2",
+    "prettier": "3.5.3",
     "pv": "1.0.1",
     "shell-escape": "^0.2.0",
     "svg-term-cli": "2.1.1",
     "toml": "3.0.0",
     "ts-dedent": "^2.2.0",
-    "ts-jest": "^29.0.3",
-    "typescript": "^5.0.0",
-    "which": "^6.0.0",
-    "zod": "^4.0.0"
+    "ts-jest": "^29.2.6",
+    "typescript": "^5.8.2",
+    "which": "^5.0.0",
+    "zod": "^3.24.2"
   },
   "prettier": {
     "semi": false
-  }
+  },
+  "description": "<h1 align=\"center\">   Fast Node Manager (<code>fnm</code>)   <img alt=\"Amount of downloads\" src=\"https://img.shields.io/github/downloads/Schniz/fnm/total.svg?style=flat\" />   <a href=\"https://github.com/Schniz/fnm/actions\"><img src=\"https://img.shields.io/github/actions/workflow/status/Schniz/fnm/rust.yml?branch=master&label=workflow\" alt=\"GitHub Actions workflow status\" /></a> </h1>",
+  "bugs": {
+    "url": "https://github.com/Schniz/fnm/issues"
+  },
+  "homepage": "https://github.com/Schniz/fnm#readme",
+  "main": "jest.global-setup.js",
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
+  },
+  "keywords": []
 }


### PR DESCRIPTION
Reverts Dargon789/fnm#118

## Summary by Sourcery

CI:
- Adjust release workflow to only trigger on pushes to the master branch, removing the main branch trigger.