### PR TITLE
Revert "Remove 'main' branch from release workflow triggers (#115)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
This reverts commit 21b6cc151cac241175b2cbd2a640ac05104add6a.

## Summary by Sourcery

CI:
- Re-enable the release workflow to run on pushes to the main branch in addition to master.