### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: release
 on:
   push:
     branches:
-      - master
       - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the release workflow trigger to stop running on the deprecated master branch and only trigger on main.