### PR TITLE
Revert "Downgrade pnpm/action-setup version to v4.0.0 (#111)"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,3 @@
-
 name: Rust
 
 on:
@@ -116,7 +115,7 @@ jobs:
           path: target/release
       - name: mark binary as executable
         run: chmod +x target/release/fnm
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           run_install: false
       - uses: actions/setup-node@v4
@@ -151,7 +150,7 @@ jobs:
           name: fnm-windows
           path: target/release
       - uses: MinoruSekine/setup-scoop@v4
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           run_install: false
       - uses: actions/setup-node@v4
@@ -223,7 +222,7 @@ jobs:
           path: target/release
       - name: mark binary as executable
         run: chmod +x target/release/fnm
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           run_install: false
       - uses: actions/setup-node@v4
@@ -348,7 +347,7 @@ jobs:
         run: |
           sudo install target/release/fnm /bin
           fnm --version
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           run_install: false
       - uses: actions/setup-node@v4


### PR DESCRIPTION
This reverts commit 0c9c155703736cb37a0758839deb2dcd8b6c39e2.

## Summary by Sourcery

CI:
- Update pnpm/action-setup from v4.0.0 back to v4.2.0 across Rust GitHub Actions workflows.