### PR TITLE
Revert "Dargon789 patch 14"

### DIFF
--- a/.changeset/itchy-rice-beg.md
+++ b/.changeset/itchy-rice-beg.md
@@ -1,5 +1,0 @@
----
-"fnm": patch
----
-
-Renovate/dawidd6 action download artifact 3.x

--- a/.changeset/smart-ladybugs-punch.md
+++ b/.changeset/smart-ladybugs-punch.md
@@ -1,5 +1,0 @@
----
-"fnm": patch
----
-
-Upgrade dawidd6/action-download-artifact to v3.


### PR DESCRIPTION
Reverts Dargon789/fnm#159

## Summary by Sourcery

Chores:
- Delete obsolete changeset entries associated with the reverted patch.