### PR TITLE
Dargon789 patch 9

### DIFF
--- a/.changeset/popular-falcons-grab.md
+++ b/.changeset/popular-falcons-grab.md
@@ -1,0 +1,5 @@
+---
+"fnm": patch
+---
+
+Dargon789 patch 9

--- a/.changeset/popular-falcons-grab.md
+++ b/.changeset/popular-falcons-grab.md
@@ -2,4 +2,4 @@
 "fnm": patch
 ---
 
-Dargon789 patch 9
+Use command.status() instead of command.output() for hook execution to avoid unnecessary output buffering.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -157,15 +157,15 @@ impl<'a> HooksManager<'a> {
                 .stderr(Stdio::inherit());
 
             // Execute the hook
-            let output = command.output()?;
+            let status = command.status()?;
             
-            if output.status.success() {
+            if status.success() {
                 debug!("Hook {} executed successfully", hook_type.name());
                 Ok(())
             } else {
                 Err(HookError::HookExecutionFailed {
                     hook_name: hook_type.name().to_string(),
-                    exit_code: output.status.code(),
+                    exit_code: status.code(),
                 })
             }
         } else {


### PR DESCRIPTION
## Summary by Sourcery

Adjust hook execution to use process exit status directly, update release workflow branches, and add a changeset entry for a patch release.

Bug Fixes:
- Use process exit status instead of full command output when running hooks to avoid unnecessary output handling.

CI:
- Update release workflow to trigger only on pushes to the master branch.

Chores:
- Add a changeset file documenting this patch release.